### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM registry.access.redhat.com/ubi8/go-toolset:1.16.7 as builder
+ENV GOPATH=$APP_ROOT
+COPY . .
+RUN make server
+
+FROM registry.access.redhat.com/ubi8-micro
+COPY --from=builder /opt/app-root/src/bin/serve /usr/local/bin/tackle-hub
+ENTRYPOINT ["/usr/local/bin/tackle-hub"]
+
+LABEL name="konveyor/tackle-hub" \
+      description="Konveyor Tackle - Hub" \
+      help="For more information visit https://konveyor.io" \
+      license="Apache License 2.0" \
+      maintainers="jortel@redhat.com,slucidi@redhat.com" \
+      summary="Konveyor Tackle - Hub" \
+      url="https://quay.io/repository/konveyor/tackle-hub" \
+      usage="podman run konveyor/tackle-hub:latest" \
+      com.redhat.component="konveyor-forklift-controller-container" \
+      io.k8s.display-name="Tackle Hub" \
+      io.k8s.description="Konveyor Tackle - Hub" \
+      io.openshift.expose-services="" \
+      io.openshift.tags="konveyor,tackle,hub" \
+      io.openshift.min-cpu="100m" \
+      io.openshift.min-memory="350Mi"


### PR DESCRIPTION
This pull request adds the Dockerfile to allow building the container image.
The final image is based on `ubi8-micro`, as it allows to shrink the image size from 136MB with `ubi8-minimal` to 58.7MB.
To copy files from/to the container, one can use other mechanism than `kubectl cp`, e.g.:

 ```
kubectl exec -n <namespace> <podname> -- "cat <filename> | base64 -" | base64 -d - > <filename>
```