### PR TITLE
Expose REST resources instead of models in the API.

### DIFF
--- a/addon/application.go
+++ b/addon/application.go
@@ -2,7 +2,6 @@ package addon
 
 import (
 	"github.com/konveyor/tackle-hub/api"
-	"github.com/konveyor/tackle-hub/model"
 	pathlib "path"
 	"strconv"
 )
@@ -56,7 +55,7 @@ type Artifact struct {
 //
 // Upload an artifact.
 func (h *Artifact) Upload(application uint, kind string, path string) (err error) {
-	artifact := &model.Artifact{}
+	artifact := &api.Artifact{}
 	artifact.CreateUser = "addon"
 	artifact.Name = pathlib.Base(path)
 	artifact.ApplicationID = application

--- a/addon/tag.go
+++ b/addon/tag.go
@@ -2,7 +2,6 @@ package addon
 
 import (
 	"github.com/konveyor/tackle-hub/api"
-	"github.com/konveyor/tackle-hub/model"
 	pathlib "path"
 	"strconv"
 )
@@ -16,15 +15,15 @@ type Tag struct {
 
 //
 // Create a tag.
-func (h *Tag) Create(m *model.Tag) (err error) {
+func (h *Tag) Create(m *api.Tag) (err error) {
 	err = h.client.Post(api.TagsRoot, m)
 	return
 }
 
 //
 // Get a tag by ID.
-func (h *Tag) Get(id uint) (m *model.Tag, err error) {
-	m = &model.Tag{}
+func (h *Tag) Get(id uint) (m *api.Tag, err error) {
+	m = &api.Tag{}
 	err = h.client.Get(
 		pathlib.Join(
 			api.TagsRoot,
@@ -35,15 +34,15 @@ func (h *Tag) Get(id uint) (m *model.Tag, err error) {
 
 //
 // List tags.
-func (h *Tag) List() (list []model.Tag, err error) {
-	list = []model.Tag{}
+func (h *Tag) List() (list []api.Tag, err error) {
+	list = []api.Tag{}
 	err = h.client.Get(api.TagsRoot, &list)
 	return
 }
 
 //
 // Delete a tag.
-func (h *Tag) Delete(m *model.Tag) (err error) {
+func (h *Tag) Delete(m *api.Tag) (err error) {
 	err = h.client.Delete(
 		pathlib.Join(
 			api.TagsRoot,
@@ -60,15 +59,15 @@ type TagType struct {
 
 //
 // Create a tag-type.
-func (h *TagType) Create(m *model.TagType) (err error) {
+func (h *TagType) Create(m *api.TagType) (err error) {
 	err = h.client.Post(api.TagTypesRoot, m)
 	return
 }
 
 //
 // Get a tag-type by ID.
-func (h *TagType) Get(id uint) (m *model.TagType, err error) {
-	m = &model.TagType{}
+func (h *TagType) Get(id uint) (m *api.TagType, err error) {
+	m = &api.TagType{}
 	err = h.client.Get(
 		pathlib.Join(
 			api.TagTypesRoot,
@@ -79,15 +78,15 @@ func (h *TagType) Get(id uint) (m *model.TagType, err error) {
 
 //
 // List tag-types.
-func (h *TagType) List() (list []model.TagType, err error) {
-	list = []model.TagType{}
+func (h *TagType) List() (list []api.TagType, err error) {
+	list = []api.TagType{}
 	err = h.client.Get(api.TagTypesRoot, &list)
 	return
 }
 
 //
 // Delete a tag-type.
-func (h *TagType) Delete(m *model.TagType) (err error) {
+func (h *TagType) Delete(m *api.TagType) (err error) {
 	err = h.client.Delete(
 		pathlib.Join(
 			api.TagTypesRoot,

--- a/addon/task.go
+++ b/addon/task.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/konveyor/tackle-hub/api"
-	"github.com/konveyor/tackle-hub/model"
 	"github.com/konveyor/tackle-hub/task"
 	pathlib "path"
 	"strconv"
@@ -19,7 +18,7 @@ type Task struct {
 	// Addon Secret
 	secret *task.Secret
 	// Task report.
-	report model.TaskReport
+	report api.TaskReport
 
 }
 
@@ -76,7 +75,7 @@ func (h *Task) Activity(word ...string) (err error) {
 // Total report addon total items.
 func (h *Task) Total(n int) (err error) {
 	h.report.Total = n
-	err = h.postReport()
+	err = h.putReport()
 	return
 }
 

--- a/api/artifact.go
+++ b/api/artifact.go
@@ -40,11 +40,11 @@ func (h ArtifactHandler) AddRoutes(e *gin.Engine) {
 // @description Get a artifact by ID.
 // @artifacts get
 // @produce json
-// @success 200 {object} model.Artifact
+// @success 200 {object} Artifact
 // @router /controls/artifact/:id [get]
 // @param id path string true "Artifact ID"
 func (h ArtifactHandler) Get(ctx *gin.Context) {
-	artifact := model.Artifact{}
+	artifact := Artifact{}
 	id := ctx.Param(ID)
 	result := h.DB.First(&artifact, id)
 	if result.Error != nil {
@@ -60,11 +60,11 @@ func (h ArtifactHandler) Get(ctx *gin.Context) {
 // @description List all artifacts.
 // @artifacts get
 // @produce json
-// @success 200 {object} model.Artifact
+// @success 200 {object} Artifact
 // @router /controls/artifact [get]
 func (h ArtifactHandler) List(ctx *gin.Context) {
 	appId := ctx.Param(ID)
-	var list []model.Artifact
+	var list []Artifact
 	pagination := NewPagination(ctx)
 	db := pagination.apply(h.DB)
 	if len(appId) > 0 {
@@ -85,11 +85,11 @@ func (h ArtifactHandler) List(ctx *gin.Context) {
 // @artifacts create
 // @accept json
 // @produce json
-// @success 200 {object} model.Artifact
+// @success 200 {object} Artifact
 // @router /controls/artifact [post]
-// @param artifact body model.Artifact true "Artifact data"
+// @param artifact body Artifact true "Artifact data"
 func (h ArtifactHandler) Create(ctx *gin.Context) {
-	artifact := model.Artifact{}
+	artifact := Artifact{}
 	err := ctx.BindJSON(&artifact)
 	if err != nil {
 		h.createFailed(ctx, err)
@@ -115,12 +115,12 @@ func (h ArtifactHandler) Create(ctx *gin.Context) {
 // @summary Delete a artifact.
 // @description Delete a artifact.
 // @artifacts delete
-// @success 200 {object} model.Artifact
+// @success 200 {object} Artifact
 // @router /controls/artifact/:id [delete]
 // @param id path string true "Artifact ID"
 func (h ArtifactHandler) Delete(ctx *gin.Context) {
 	id := ctx.Param(ID)
-	result := h.DB.Delete(&model.Artifact{}, id)
+	result := h.DB.Delete(&Artifact{}, id)
 	if result.Error != nil {
 		h.deleteFailed(ctx, result.Error)
 		return
@@ -135,19 +135,19 @@ func (h ArtifactHandler) Delete(ctx *gin.Context) {
 // @artifacts update
 // @accept json
 // @produce json
-// @success 200 {object} model.Artifact
+// @success 200 {object} Artifact
 // @router /controls/artifact/:id [put]
 // @param id path string true "Artifact ID"
-// @param artifact body model.Artifact true "Artifact data"
+// @param artifact body Artifact true "Artifact data"
 func (h ArtifactHandler) Update(ctx *gin.Context) {
 	id := ctx.Param(ID)
-	updates := model.Artifact{}
+	updates := Artifact{}
 	err := ctx.BindJSON(&updates)
 	if err != nil {
 		h.updateFailed(ctx, err)
 		return
 	}
-	result := h.DB.Model(&model.Artifact{}).Where("id = ?", id).Omit("id").Updates(updates)
+	result := h.DB.Model(&Artifact{}).Where("id = ?", id).Omit("id").Updates(updates)
 	if result.Error != nil {
 		h.updateFailed(ctx, result.Error)
 		return
@@ -155,3 +155,7 @@ func (h ArtifactHandler) Update(ctx *gin.Context) {
 
 	ctx.Status(http.StatusOK)
 }
+
+//
+// Artifact REST resource.
+type Artifact = model.Artifact

--- a/api/businessservice.go
+++ b/api/businessservice.go
@@ -41,11 +41,11 @@ func (h BusinessServiceHandler) AddRoutes(e *gin.Engine) {
 // @description Get a business service by ID.
 // @tags get
 // @produce json
-// @success 200 {object} model.BusinessService
+// @success 200 {object} BusinessService
 // @router /controls/business-service/:id [get]
 // @param id path string true "Business Service ID"
 func (h BusinessServiceHandler) Get(ctx *gin.Context) {
-	model := model.BusinessService{}
+	model := BusinessService{}
 	id := ctx.Param(ID)
 	db := h.preLoad(h.DB, "Stakeholder")
 	result := db.First(&model, id)
@@ -62,12 +62,12 @@ func (h BusinessServiceHandler) Get(ctx *gin.Context) {
 // @description List all business services.
 // @tags list
 // @produce json
-// @success 200 {object} model.BusinessService
+// @success 200 {object} BusinessService
 // @router /controls/business-service [get]
 func (h BusinessServiceHandler) List(ctx *gin.Context) {
 	var count int64
-	var models []model.BusinessService
-	h.DB.Model(model.BusinessService{}).Count(&count)
+	var models []BusinessService
+	h.DB.Model(BusinessService{}).Count(&count)
 	pagination := NewPagination(ctx)
 	db := pagination.apply(h.DB)
 	db = h.preLoad(db, "Stakeholder")
@@ -86,11 +86,11 @@ func (h BusinessServiceHandler) List(ctx *gin.Context) {
 // @tags create
 // @accept json
 // @produce json
-// @success 200 {object} model.BusinessService
+// @success 200 {object} BusinessService
 // @router /controls/business-service [post]
-// @param business_service body model.BusinessService true "Business service data"
+// @param business_service body BusinessService true "Business service data"
 func (h BusinessServiceHandler) Create(ctx *gin.Context) {
-	model := model.BusinessService{}
+	model := BusinessService{}
 	err := ctx.BindJSON(&model)
 	if err != nil {
 		h.createFailed(ctx, err)
@@ -109,12 +109,12 @@ func (h BusinessServiceHandler) Create(ctx *gin.Context) {
 // @summary Delete a business service.
 // @description Delete a business service.
 // @tags delete
-// @success 200 {object} model.BusinessService
+// @success 200 {object} BusinessService
 // @router /controls/business-service/:id [delete]
 // @param id path string true "Business service ID"
 func (h BusinessServiceHandler) Delete(ctx *gin.Context) {
 	id := ctx.Param(ID)
-	result := h.DB.Delete(&model.BusinessService{}, id)
+	result := h.DB.Delete(&BusinessService{}, id)
 	if result.Error != nil {
 		h.deleteFailed(ctx, result.Error)
 		return
@@ -129,19 +129,19 @@ func (h BusinessServiceHandler) Delete(ctx *gin.Context) {
 // @tags update
 // @accept json
 // @produce json
-// @success 200 {object} model.BusinessService
+// @success 200 {object} BusinessService
 // @router /controls/business-service/:id [put]
 // @param id path string true "Business service ID"
-// @param business_service body model.BusinessService true "Business service data"
+// @param business_service body BusinessService true "Business service data"
 func (h BusinessServiceHandler) Update(ctx *gin.Context) {
 	id := ctx.Param(ID)
-	updates := model.BusinessService{}
+	updates := BusinessService{}
 	err := ctx.BindJSON(&updates)
 	if err != nil {
 		h.updateFailed(ctx, err)
 		return
 	}
-	result := h.DB.Model(&model.BusinessService{}).Where("id = ?", id).Omit("id").Updates(updates)
+	result := h.DB.Model(&BusinessService{}).Where("id = ?", id).Omit("id").Updates(updates)
 	if result.Error != nil {
 		h.updateFailed(ctx, result.Error)
 		return
@@ -149,3 +149,7 @@ func (h BusinessServiceHandler) Update(ctx *gin.Context) {
 
 	ctx.Status(http.StatusOK)
 }
+
+//
+// BusinessService REST resource.
+type BusinessService = model.BusinessService

--- a/api/group.go
+++ b/api/group.go
@@ -45,7 +45,7 @@ func (h StakeholderGroupHandler) AddRoutes(e *gin.Engine) {
 // @router /controls/stakeholder-group/:id [get]
 // @param id path string true "Stakeholder Group ID"
 func (h StakeholderGroupHandler) Get(ctx *gin.Context) {
-	model := model.StakeholderGroup{}
+	model := StakeholderGroup{}
 	id := ctx.Param(ID)
 	db := h.preLoad(h.DB, "Stakeholders")
 	result := db.First(&model, id)
@@ -66,8 +66,8 @@ func (h StakeholderGroupHandler) Get(ctx *gin.Context) {
 // @router /controls/stakeholder-group [get]
 func (h StakeholderGroupHandler) List(ctx *gin.Context) {
 	var count int64
-	var models []model.StakeholderGroup
-	h.DB.Model(model.StakeholderGroup{}).Count(&count)
+	var models []StakeholderGroup
+	h.DB.Model(StakeholderGroup{}).Count(&count)
 	pagination := NewPagination(ctx)
 	db := pagination.apply(h.DB)
 	db = h.preLoad(h.DB, "Stakeholders")
@@ -90,7 +90,7 @@ func (h StakeholderGroupHandler) List(ctx *gin.Context) {
 // @router /controls/stakeholder-group [post]
 // @param stakeholder_group body models.StakeholderGroup true "Stakeholder Group data"
 func (h StakeholderGroupHandler) Create(ctx *gin.Context) {
-	model := model.StakeholderGroup{}
+	model := StakeholderGroup{}
 	err := ctx.BindJSON(&model)
 	if err != nil {
 		h.createFailed(ctx, err)
@@ -114,7 +114,7 @@ func (h StakeholderGroupHandler) Create(ctx *gin.Context) {
 // @param id path string true "Stakeholder Group ID"
 func (h StakeholderGroupHandler) Delete(ctx *gin.Context) {
 	id := ctx.Param(ID)
-	result := h.DB.Delete(&model.StakeholderGroup{}, id)
+	result := h.DB.Delete(&StakeholderGroup{}, id)
 	if result.Error != nil {
 		h.deleteFailed(ctx, result.Error)
 		return
@@ -135,13 +135,13 @@ func (h StakeholderGroupHandler) Delete(ctx *gin.Context) {
 // @param stakeholder_group body models.StakeholderGroup true "Stakeholder Group data"
 func (h StakeholderGroupHandler) Update(ctx *gin.Context) {
 	id := ctx.Param(ID)
-	updates := model.StakeholderGroup{}
+	updates := StakeholderGroup{}
 	err := ctx.BindJSON(&updates)
 	if err != nil {
 		h.updateFailed(ctx, err)
 		return
 	}
-	result := h.DB.Model(&model.StakeholderGroup{}).Where("id = ?", id).Omit("id").Updates(updates)
+	result := h.DB.Model(&StakeholderGroup{}).Where("id = ?", id).Omit("id").Updates(updates)
 	if result.Error != nil {
 		h.updateFailed(ctx, result.Error)
 		return
@@ -149,3 +149,7 @@ func (h StakeholderGroupHandler) Update(ctx *gin.Context) {
 
 	ctx.Status(http.StatusOK)
 }
+
+//
+// StakeholderGroup REST resource.
+type StakeholderGroup = model.StakeholderGroup

--- a/api/jobfunction.go
+++ b/api/jobfunction.go
@@ -41,11 +41,11 @@ func (h JobFunctionHandler) AddRoutes(e *gin.Engine) {
 // @description Get a job function by ID.
 // @tags get
 // @produce json
-// @success 200 {object} model.JobFunction
+// @success 200 {object} JobFunction
 // @router /controls/job-function/:id [get]
 // @param id path string true "Job Function ID"
 func (h JobFunctionHandler) Get(ctx *gin.Context) {
-	model := model.JobFunction{}
+	model := JobFunction{}
 	id := ctx.Param(ID)
 	db := h.preLoad(h.DB, "Stakeholders")
 	result := db.First(&model, id)
@@ -62,12 +62,12 @@ func (h JobFunctionHandler) Get(ctx *gin.Context) {
 // @description List all job functions.
 // @tags get
 // @produce json
-// @success 200 {object} model.JobFunction
+// @success 200 {object} JobFunction
 // @router /controls/job-function [get]
 func (h JobFunctionHandler) List(ctx *gin.Context) {
 	var count int64
-	var models []model.JobFunction
-	h.DB.Model(model.JobFunction{}).Count(&count)
+	var models []JobFunction
+	h.DB.Model(JobFunction{}).Count(&count)
 	pagination := NewPagination(ctx)
 	db := pagination.apply(h.DB)
 	db = h.preLoad(db, "Stakeholders")
@@ -86,11 +86,11 @@ func (h JobFunctionHandler) List(ctx *gin.Context) {
 // @tags create
 // @accept json
 // @produce json
-// @success 200 {object} model.JobFunction
+// @success 200 {object} JobFunction
 // @router /controls/job-function [post]
-// @param job_function body model.JobFunction true "Job Function data"
+// @param job_function body JobFunction true "Job Function data"
 func (h JobFunctionHandler) Create(ctx *gin.Context) {
-	model := model.JobFunction{}
+	model := JobFunction{}
 	err := ctx.BindJSON(&model)
 	if err != nil {
 		h.createFailed(ctx, err)
@@ -109,12 +109,12 @@ func (h JobFunctionHandler) Create(ctx *gin.Context) {
 // @summary Delete a job function.
 // @description Delete a job function.
 // @tags delete
-// @success 200 {object} model.JobFunction
+// @success 200 {object} JobFunction
 // @router /controls/job-function/:id [delete]
 // @param id path string true "Job Function ID"
 func (h JobFunctionHandler) Delete(ctx *gin.Context) {
 	id := ctx.Param(ID)
-	result := h.DB.Delete(&model.JobFunction{}, id)
+	result := h.DB.Delete(&JobFunction{}, id)
 	if result.Error != nil {
 		h.deleteFailed(ctx, result.Error)
 		return
@@ -129,19 +129,19 @@ func (h JobFunctionHandler) Delete(ctx *gin.Context) {
 // @tags update
 // @accept json
 // @produce json
-// @success 200 {object} model.JobFunction
+// @success 200 {object} JobFunction
 // @router /controls/job-function/:id [put]
 // @param id path string true "Job Function ID"
-// @param job_function body model.JobFunction true "Job Function data"
+// @param job_function body JobFunction true "Job Function data"
 func (h JobFunctionHandler) Update(ctx *gin.Context) {
 	id := ctx.Param(ID)
-	updates := model.JobFunction{}
+	updates := JobFunction{}
 	err := ctx.BindJSON(&updates)
 	if err != nil {
 		h.updateFailed(ctx, err)
 		return
 	}
-	result := h.DB.Model(&model.JobFunction{}).Where("id = ?", id).Omit("id").Updates(updates)
+	result := h.DB.Model(&JobFunction{}).Where("id = ?", id).Omit("id").Updates(updates)
 	if result.Error != nil {
 		h.updateFailed(ctx, result.Error)
 		return
@@ -149,3 +149,7 @@ func (h JobFunctionHandler) Update(ctx *gin.Context) {
 
 	ctx.Status(http.StatusOK)
 }
+
+//
+// JobFunction REST resrouce.
+type JobFunction = model.JobFunction

--- a/api/review.go
+++ b/api/review.go
@@ -41,11 +41,11 @@ func (h ReviewHandler) AddRoutes(e *gin.Engine) {
 // @description Get a review by ID.
 // @tags get
 // @produce json
-// @success 200 {object} model.Review
+// @success 200 {object} Review
 // @router /application-inventory/review/:id [get]
 // @param id path string true "Review ID"
 func (h ReviewHandler) Get(ctx *gin.Context) {
-	model := model.Review{}
+	model := Review{}
 	id := ctx.Param(ID)
 	db := h.preLoad(h.DB, "Application")
 	result := db.First(&model, id)
@@ -62,12 +62,12 @@ func (h ReviewHandler) Get(ctx *gin.Context) {
 // @description List all reviews.
 // @tags get
 // @produce json
-// @success 200 {object} model.Review
+// @success 200 {object} Review
 // @router /application-inventory/review [get]
 func (h ReviewHandler) List(ctx *gin.Context) {
 	var count int64
-	var models []model.Review
-	h.DB.Model(model.Review{}).Count(&count)
+	var models []Review
+	h.DB.Model(Review{}).Count(&count)
 	pagination := NewPagination(ctx)
 	db := pagination.apply(h.DB)
 	db = h.preLoad(db, "Application")
@@ -86,11 +86,11 @@ func (h ReviewHandler) List(ctx *gin.Context) {
 // @tags create
 // @accept json
 // @produce json
-// @success 200 {object} model.Review
+// @success 200 {object} Review
 // @router /application-inventory/review [post]
-// @param review body model.Review true "Review data"
+// @param review body Review true "Review data"
 func (h ReviewHandler) Create(ctx *gin.Context) {
-	model := model.Review{}
+	model := Review{}
 	err := ctx.BindJSON(&model)
 	if err != nil {
 		h.createFailed(ctx, err)
@@ -109,12 +109,12 @@ func (h ReviewHandler) Create(ctx *gin.Context) {
 // @summary Delete a review.
 // @description Delete a review.
 // @tags delete
-// @success 200 {object} model.Review
+// @success 200 {object} Review
 // @router /application-inventory/review/:id [delete]
 // @param id path string true "Review ID"
 func (h ReviewHandler) Delete(ctx *gin.Context) {
 	id := ctx.Param(ID)
-	result := h.DB.Delete(&model.Review{}, id)
+	result := h.DB.Delete(&Review{}, id)
 	if result.Error != nil {
 		h.deleteFailed(ctx, result.Error)
 		return
@@ -129,19 +129,19 @@ func (h ReviewHandler) Delete(ctx *gin.Context) {
 // @tags update
 // @accept json
 // @produce json
-// @success 200 {object} model.Review
+// @success 200 {object} Review
 // @router /application-inventory/review/:id [put]
 // @param id path string true "Review ID"
-// @param review body model.Review true "Review data"
+// @param review body Review true "Review data"
 func (h ReviewHandler) Update(ctx *gin.Context) {
 	id := ctx.Param(ID)
-	updates := model.Review{}
+	updates := Review{}
 	err := ctx.BindJSON(&updates)
 	if err != nil {
 		h.updateFailed(ctx, err)
 		return
 	}
-	result := h.DB.Model(&model.Review{}).Where("id = ?", id).Omit("id").Updates(updates)
+	result := h.DB.Model(&Review{}).Where("id = ?", id).Omit("id").Updates(updates)
 	if result.Error != nil {
 		h.updateFailed(ctx, result.Error)
 		return
@@ -149,3 +149,7 @@ func (h ReviewHandler) Update(ctx *gin.Context) {
 
 	ctx.Status(http.StatusOK)
 }
+
+//
+// Review REST resource.
+type Review = model.Review

--- a/api/stakeholder.go
+++ b/api/stakeholder.go
@@ -41,11 +41,11 @@ func (h StakeholderHandler) AddRoutes(e *gin.Engine) {
 // @description Get a stakeholder by ID.
 // @tags get
 // @produce json
-// @success 200 {object} model.Stakeholder
+// @success 200 {object} Stakeholder
 // @router /controls/stakeholder/:id [get]
 // @param id path string true "Stakeholder ID"
 func (h StakeholderHandler) Get(ctx *gin.Context) {
-	model := model.Stakeholder{}
+	model := Stakeholder{}
 	id := ctx.Param(ID)
 	db := h.preLoad(
 		h.DB,
@@ -66,12 +66,12 @@ func (h StakeholderHandler) Get(ctx *gin.Context) {
 // @description List all stakeholders.
 // @tags get
 // @produce json
-// @success 200 {object} model.Stakeholder
+// @success 200 {object} Stakeholder
 // @router /controls/stakeholder [get]
 func (h StakeholderHandler) List(ctx *gin.Context) {
 	var count int64
-	var models []model.Stakeholder
-	h.DB.Model(model.Stakeholder{}).Count(&count)
+	var models []Stakeholder
+	h.DB.Model(Stakeholder{}).Count(&count)
 	pagination := NewPagination(ctx)
 	db := pagination.apply(h.DB)
 	db = h.preLoad(
@@ -94,11 +94,11 @@ func (h StakeholderHandler) List(ctx *gin.Context) {
 // @tags create
 // @accept json
 // @produce json
-// @success 200 {object} model.Stakeholder
+// @success 200 {object} Stakeholder
 // @router /controls/stakeholder [post]
-// @param stakeholder body model.Stakeholder true "Stakeholder data"
+// @param stakeholder body Stakeholder true "Stakeholder data"
 func (h StakeholderHandler) Create(ctx *gin.Context) {
-	model := model.Stakeholder{}
+	model := Stakeholder{}
 	err := ctx.BindJSON(&model)
 	if err != nil {
 		h.createFailed(ctx, err)
@@ -117,12 +117,12 @@ func (h StakeholderHandler) Create(ctx *gin.Context) {
 // @summary Delete a stakeholder.
 // @description Delete a stakeholder.
 // @tags delete
-// @success 200 {object} model.Stakeholder
+// @success 200 {object} Stakeholder
 // @router /controls/stakeholder/:id [delete]
 // @param id path string true "Stakeholder ID"
 func (h StakeholderHandler) Delete(ctx *gin.Context) {
 	id := ctx.Param(ID)
-	result := h.DB.Delete(&model.Stakeholder{}, id)
+	result := h.DB.Delete(&Stakeholder{}, id)
 	if result.Error != nil {
 		h.deleteFailed(ctx, result.Error)
 		return
@@ -137,19 +137,19 @@ func (h StakeholderHandler) Delete(ctx *gin.Context) {
 // @tags update
 // @accept json
 // @produce json
-// @success 200 {object} model.Stakeholder
+// @success 200 {object} Stakeholder
 // @router /controls/stakeholder/:id [put]
 // @param id path string true "Stakeholder ID"
-// @param stakeholder body model.Stakeholder true "Stakeholder data"
+// @param stakeholder body Stakeholder true "Stakeholder data"
 func (h StakeholderHandler) Update(ctx *gin.Context) {
 	id := ctx.Param(ID)
-	updates := model.Stakeholder{}
+	updates := Stakeholder{}
 	err := ctx.BindJSON(&updates)
 	if err != nil {
 		h.updateFailed(ctx, err)
 		return
 	}
-	result := h.DB.Model(&model.Stakeholder{}).Where("id = ?", id).Omit("id").Updates(updates)
+	result := h.DB.Model(&Stakeholder{}).Where("id = ?", id).Omit("id").Updates(updates)
 	if result.Error != nil {
 		h.updateFailed(ctx, result.Error)
 		return
@@ -157,3 +157,7 @@ func (h StakeholderHandler) Update(ctx *gin.Context) {
 
 	ctx.Status(http.StatusOK)
 }
+
+//
+// Stakeholder REST resource.
+type Stakeholder = model.Stakeholder

--- a/api/tag.go
+++ b/api/tag.go
@@ -41,11 +41,11 @@ func (h TagHandler) AddRoutes(e *gin.Engine) {
 // @description Get a tag by ID.
 // @tags get
 // @produce json
-// @success 200 {object} model.Tag
+// @success 200 {object} Tag
 // @router /controls/tag/:id [get]
 // @param id path string true "Tag ID"
 func (h TagHandler) Get(ctx *gin.Context) {
-	model := model.Tag{}
+	model := Tag{}
 	id := ctx.Param(ID)
 	db := h.preLoad(h.DB, "TagType")
 	result := db.First(&model, id)
@@ -62,12 +62,12 @@ func (h TagHandler) Get(ctx *gin.Context) {
 // @description List all tags.
 // @tags get
 // @produce json
-// @success 200 {object} model.Tag
+// @success 200 {object} Tag
 // @router /controls/tag [get]
 func (h TagHandler) List(ctx *gin.Context) {
 	var count int64
-	var models []model.Tag
-	h.DB.Model(model.Tag{}).Count(&count)
+	var models []Tag
+	h.DB.Model(Tag{}).Count(&count)
 	pagination := NewPagination(ctx)
 	db := pagination.apply(h.DB)
 	db = h.preLoad(db, "TagType")
@@ -86,11 +86,11 @@ func (h TagHandler) List(ctx *gin.Context) {
 // @tags create
 // @accept json
 // @produce json
-// @success 200 {object} model.Tag
+// @success 200 {object} Tag
 // @router /controls/tag [post]
-// @param tag body model.Tag true "Tag data"
+// @param tag body Tag true "Tag data"
 func (h TagHandler) Create(ctx *gin.Context) {
-	model := model.Tag{}
+	model := Tag{}
 	err := ctx.BindJSON(&model)
 	if err != nil {
 		h.createFailed(ctx, err)
@@ -108,12 +108,12 @@ func (h TagHandler) Create(ctx *gin.Context) {
 // @summary Delete a tag.
 // @description Delete a tag.
 // @tags delete
-// @success 200 {object} model.Tag
+// @success 200 {object} Tag
 // @router /controls/tag/:id [delete]
 // @param id path string true "Tag ID"
 func (h TagHandler) Delete(ctx *gin.Context) {
 	id := ctx.Param(ID)
-	result := h.DB.Delete(&model.Tag{}, id)
+	result := h.DB.Delete(&Tag{}, id)
 	if result.Error != nil {
 		h.deleteFailed(ctx, result.Error)
 		return
@@ -128,19 +128,19 @@ func (h TagHandler) Delete(ctx *gin.Context) {
 // @tags update
 // @accept json
 // @produce json
-// @success 200 {object} model.Tag
+// @success 200 {object} Tag
 // @router /controls/tag/:id [put]
 // @param id path string true "Tag ID"
-// @param tag body model.Tag true "Tag data"
+// @param tag body Tag true "Tag data"
 func (h TagHandler) Update(ctx *gin.Context) {
 	id := ctx.Param(ID)
-	updates := model.Tag{}
+	updates := Tag{}
 	err := ctx.BindJSON(&updates)
 	if err != nil {
 		h.updateFailed(ctx, err)
 		return
 	}
-	result := h.DB.Model(&model.Tag{}).Where("id = ?", id).Omit("id").Updates(updates)
+	result := h.DB.Model(&Tag{}).Where("id = ?", id).Omit("id").Updates(updates)
 	if result.Error != nil {
 		h.updateFailed(ctx, result.Error)
 		return
@@ -148,3 +148,7 @@ func (h TagHandler) Update(ctx *gin.Context) {
 
 	ctx.Status(http.StatusOK)
 }
+
+//
+// Tag REST resource.
+type Tag = model.Tag

--- a/api/tagtype.go
+++ b/api/tagtype.go
@@ -41,11 +41,11 @@ func (h TagTypeHandler) AddRoutes(e *gin.Engine) {
 // @description Get a tag type by ID.
 // @tags get
 // @produce json
-// @success 200 {object} model.TagType
+// @success 200 {object} TagType
 // @router /controls/tag-type/:id [get]
 // @param id path string true "Tag Type ID"
 func (h TagTypeHandler) Get(ctx *gin.Context) {
-	model := model.TagType{}
+	model := TagType{}
 	id := ctx.Param(ID)
 	db := h.preLoad(h.DB, "Tags")
 	result := db.First(&model, id)
@@ -62,12 +62,12 @@ func (h TagTypeHandler) Get(ctx *gin.Context) {
 // @description List all tag types.
 // @tags get
 // @produce json
-// @success 200 {object} model.TagType
+// @success 200 {object} TagType
 // @router /controls/tag-type [get]
 func (h TagTypeHandler) List(ctx *gin.Context) {
 	var count int64
-	var models []model.TagType
-	h.DB.Model(model.TagType{}).Count(&count)
+	var models []TagType
+	h.DB.Model(TagType{}).Count(&count)
 	pagination := NewPagination(ctx)
 	db := pagination.apply(h.DB)
 	db = h.preLoad(db, "Tags")
@@ -86,11 +86,11 @@ func (h TagTypeHandler) List(ctx *gin.Context) {
 // @tags create
 // @accept json
 // @produce json
-// @success 200 {object} model.TagType
+// @success 200 {object} TagType
 // @router /controls/tag-type [post]
-// @param tag_type body model.TagType true "Tag Type data"
+// @param tag_type body TagType true "Tag Type data"
 func (h TagTypeHandler) Create(ctx *gin.Context) {
-	model := model.TagType{}
+	model := TagType{}
 	err := ctx.BindJSON(&model)
 	if err != nil {
 		h.createFailed(ctx, err)
@@ -109,12 +109,12 @@ func (h TagTypeHandler) Create(ctx *gin.Context) {
 // @summary Delete a tag type.
 // @description Delete a tag type.
 // @tags delete
-// @success 200 {object} model.TagType
+// @success 200 {object} TagType
 // @router /controls/tag-type/:id [delete]
 // @param id path string true "Tag Type ID"
 func (h TagTypeHandler) Delete(ctx *gin.Context) {
 	id := ctx.Param(ID)
-	result := h.DB.Delete(&model.TagType{}, id)
+	result := h.DB.Delete(&TagType{}, id)
 	if result.Error != nil {
 		h.deleteFailed(ctx, result.Error)
 		return
@@ -129,19 +129,19 @@ func (h TagTypeHandler) Delete(ctx *gin.Context) {
 // @tags update
 // @accept json
 // @produce json
-// @success 200 {object} model.TagType
+// @success 200 {object} TagType
 // @router /controls/tag-type/:id [put]
 // @param id path string true "Tag Type ID"
-// @param tag_type body model.TagType true "Tag Type data"
+// @param tag_type body TagType true "Tag Type data"
 func (h TagTypeHandler) Update(ctx *gin.Context) {
 	id := ctx.Param(ID)
-	updates := model.TagType{}
+	updates := TagType{}
 	err := ctx.BindJSON(&updates)
 	if err != nil {
 		h.updateFailed(ctx, err)
 		return
 	}
-	result := h.DB.Model(&model.TagType{}).Where("id = ?", id).Omit("id").Updates(updates)
+	result := h.DB.Model(&TagType{}).Where("id = ?", id).Omit("id").Updates(updates)
 	if result.Error != nil {
 		h.updateFailed(ctx, result.Error)
 		return
@@ -149,3 +149,7 @@ func (h TagTypeHandler) Update(ctx *gin.Context) {
 
 	ctx.Status(http.StatusOK)
 }
+
+//
+// TagType REST resource.
+type TagType = model.TagType

--- a/api/task.go
+++ b/api/task.go
@@ -48,11 +48,11 @@ func (h TaskHandler) AddRoutes(e *gin.Engine) {
 // @description Get a task by ID.
 // @tags get
 // @produce json
-// @success 200 {object} model.Task
+// @success 200 {object} Task
 // @router /tasks/:id [get]
 // @param id path string true "Task ID"
 func (h TaskHandler) Get(ctx *gin.Context) {
-	task := &model.Task{}
+	task := &Task{}
 	id := ctx.Param(ID)
 	db := h.DB.Preload("Report")
 	result := db.First(task, id)
@@ -69,10 +69,10 @@ func (h TaskHandler) Get(ctx *gin.Context) {
 // @description List all tasks.
 // @tags get
 // @produce json
-// @success 200 {object} model.Task
+// @success 200 {object} Task
 // @router /tasks [get]
 func (h TaskHandler) List(ctx *gin.Context) {
-	var list []model.Task
+	var list []Task
 	pagination := NewPagination(ctx)
 	db := pagination.apply(h.DB)
 	db = db.Preload("Report")
@@ -91,11 +91,11 @@ func (h TaskHandler) List(ctx *gin.Context) {
 // @tags create
 // @accept json
 // @produce json
-// @success 200 {object} model.Task
+// @success 200 {object} Task
 // @router /tasks [post]
-// @param task body model.Task true "Task data"
+// @param task body Task true "Task data"
 func (h TaskHandler) Create(ctx *gin.Context) {
-	task := model.Task{}
+	task := Task{}
 	err := ctx.BindJSON(&task)
 	if err != nil {
 		h.createFailed(ctx, err)
@@ -135,7 +135,7 @@ func (h TaskHandler) AddonCreate(ctx *gin.Context) {
 		h.createFailed(ctx, err)
 		return
 	}
-	task := model.Task{}
+	task := Task{}
 	task.Name = addon.Name
 	task.Addon = addon.Name
 	task.Image = addon.Spec.Image
@@ -153,12 +153,12 @@ func (h TaskHandler) AddonCreate(ctx *gin.Context) {
 // @summary Delete a task.
 // @description Delete a task.
 // @tags delete
-// @success 200 {object} model.Task
+// @success 200 {object} Task
 // @router /tasks/:id [delete]
 // @param id path string true "Task ID"
 func (h TaskHandler) Delete(ctx *gin.Context) {
 	id := ctx.Param(ID)
-	task := &model.Task{}
+	task := &Task{}
 	result := h.DB.First(task, id)
 	if result.Error != nil {
 		h.deleteFailed(ctx, result.Error)
@@ -190,19 +190,19 @@ func (h TaskHandler) Delete(ctx *gin.Context) {
 // @tags update
 // @accept json
 // @produce json
-// @success 200 {object} model.Task
+// @success 200 {object} Task
 // @router /tasks/:id [put]
 // @param id path string true "Task ID"
-// @param task body model.Task true "Task data"
+// @param task body Task true "Task data"
 func (h TaskHandler) Update(ctx *gin.Context) {
 	id := ctx.Param(ID)
-	updates := model.Task{}
+	updates := Task{}
 	err := ctx.BindJSON(&updates)
 	if err != nil {
 		h.updateFailed(ctx, err)
 		return
 	}
-	result := h.DB.Model(&model.Task{}).Where("id", id).Omit("id").Updates(updates)
+	result := h.DB.Model(&Task{}).Where("id", id).Omit("id").Updates(updates)
 	if result.Error != nil {
 		h.updateFailed(ctx, result.Error)
 		return
@@ -217,13 +217,13 @@ func (h TaskHandler) Update(ctx *gin.Context) {
 // @tags update
 // @accept json
 // @produce json
-// @success 200 {object} model.TaskReport
+// @success 200 {object} TaskReport
 // @router /tasks/:id [put]
 // @param id path string true "TaskReport ID"
-// @param task body model.TaskReport true "TaskReport data"
+// @param task body TaskReport true "TaskReport data"
 func (h TaskHandler) CreateReport(ctx *gin.Context) {
 	id := ctx.Param(ID)
-	report := &model.TaskReport{}
+	report := &TaskReport{}
 	err := ctx.BindJSON(report)
 	if err != nil {
 		h.createFailed(ctx, err)
@@ -245,13 +245,13 @@ func (h TaskHandler) CreateReport(ctx *gin.Context) {
 // @tags update
 // @accept json
 // @produce json
-// @success 200 {object} model.TaskReport
+// @success 200 {object} TaskReport
 // @router /tasks/:id [put]
 // @param id path string true "TaskReport ID"
-// @param task body model.TaskReport true "TaskReport data"
+// @param task body TaskReport true "TaskReport data"
 func (h TaskHandler) UpdateReport(ctx *gin.Context) {
 	id := ctx.Param(ID)
-	report := &model.TaskReport{}
+	report := &TaskReport{}
 	err := ctx.BindJSON(report)
 	if err != nil {
 		h.updateFailed(ctx, err)
@@ -259,7 +259,7 @@ func (h TaskHandler) UpdateReport(ctx *gin.Context) {
 	}
 	task, _ := strconv.Atoi(id)
 	report.TaskID = uint(task)
-	db := h.DB.Model(&model.TaskReport{})
+	db := h.DB.Model(&TaskReport{})
 	db = db.Where("task_id", task)
 	db = db.Omit("id")
 	result := db.Updates(report)
@@ -269,3 +269,11 @@ func (h TaskHandler) UpdateReport(ctx *gin.Context) {
 
 	ctx.Status(http.StatusOK)
 }
+
+//
+// Task REST resource.
+type Task = model.Task
+
+//
+// TaskReport REST resource.
+type TaskReport = model.TaskReport

--- a/api/task.go
+++ b/api/task.go
@@ -267,7 +267,7 @@ func (h TaskHandler) UpdateReport(ctx *gin.Context) {
 		h.updateFailed(ctx, result.Error)
 	}
 
-	ctx.Status(http.StatusOK)
+	ctx.JSON(http.StatusOK, report)
 }
 
 //

--- a/hack/cmd/addon/main.go
+++ b/hack/cmd/addon/main.go
@@ -10,7 +10,7 @@ import (
 	"bytes"
 	"fmt"
 	hub "github.com/konveyor/tackle-hub/addon"
-	"github.com/konveyor/tackle-hub/model"
+	"github.com/konveyor/tackle-hub/api"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -146,7 +146,7 @@ func tag(d *Data) (err error) {
 	application, _ := addon.Application.Get(d.Application)
 	//
 	// Create tag.
-	tag := &model.Tag{
+	tag := &api.Tag{
 		Name: "MyTag",
 		TagTypeID: 1,
 	}


### PR DESCRIPTION
For now, just declare and use REST resources in the `api` package instead of models directly for proper isolation between layers.