### PR TITLE
Add tag type color in tag response

### DIFF
--- a/api/tag.go
+++ b/api/tag.go
@@ -164,8 +164,9 @@ type Tag struct {
 	ID      uint   `json:"id"`
 	Name    string `json:"name"`
 	TagType struct {
-		ID   uint   `json:"id"`
-		Name string `json:"name"`
+		ID    uint   `json:"id"`
+		Name  string `json:"name"`
+		Color string `json:"colour"`
 	} `json:"tagType"`
 }
 
@@ -176,6 +177,7 @@ func (r *Tag) With(m *model.Tag) {
 	r.Name = m.Name
 	r.TagType.ID = m.TagTypeID
 	r.TagType.Name = m.TagType.Name
+	r.TagType.Color = m.TagType.Color
 }
 
 //


### PR DESCRIPTION
The Tackle UI uses the `tag_type.colour` field of the tag response to
display the tag with the right color in the application expanded view.
This pull request simply extends the response with the tag type color.

Signed-off-by: Fabien Dupont <fabiendupont@pm.me>