### PR TITLE
Identity associated with Applications.

### DIFF
--- a/addon/proxy.go
+++ b/addon/proxy.go
@@ -22,10 +22,6 @@ func (h *Proxy) Get(id uint) (m *api.Proxy, err error) {
 			api.ProxiesRoot,
 			strconv.Itoa(int(id))),
 		m)
-	if err != nil {
-		return
-	}
-	err = m.Decrypt(Addon.secret.Hub.Encryption.Passphrase)
 	return
 }
 
@@ -36,13 +32,6 @@ func (h *Proxy) List() (list []api.Proxy, err error) {
 	err = h.client.Get(api.ProxiesRoot, &list)
 	if err != nil {
 		return
-	}
-	for i := range list {
-		m := &list[i]
-		err = m.Decrypt(Addon.secret.Hub.Encryption.Passphrase)
-		if err != nil {
-			return
-		}
 	}
 	return
 }

--- a/api/repository.go
+++ b/api/repository.go
@@ -24,11 +24,11 @@ func (h RepositoryHandler) AddRoutes(e *gin.Engine) {
 	e.GET(RepositoriesRoot, h.List)
 	e.GET(RepositoriesRoot+"/", h.List)
 	e.POST(RepositoriesRoot, h.Create)
-	e.POST(AppRepositoriesRoot, h.CreateForApplication)
-	e.GET(AppRepositoriesRoot, h.ListByApplication)
 	e.GET(RepositoryRoot, h.Get)
 	e.PUT(RepositoryRoot, h.Update)
 	e.DELETE(RepositoryRoot, h.Delete)
+	e.POST(AppRepositoriesRoot, h.CreateForApplication)
+	e.GET(AppRepositoriesRoot, h.ListByApplication)
 }
 
 // Get godoc

--- a/hack/add/app-repository.sh
+++ b/hack/add/app-repository.sh
@@ -2,11 +2,10 @@
 
 host="${HOST:-localhost:8080}"
 
-curl -X POST ${host}/repositories -d \
+curl -X POST ${host}/application-inventory/application/1/repositories -d \
 '{
     "createUser": "tackle",
-    "application": 1,
-    "name": "created-directly",
+    "name": "created-for-application",
     "kind": "git",
     "url": "git://github.com/testing"
 }' | jq -M .

--- a/hack/add/identity.sh
+++ b/hack/add/identity.sh
@@ -12,10 +12,10 @@ curl -X POST ${host}/identities -d \
     "password": "passwordA",
     "key": "keyA",
     "settings": "settingsA",
-    "repository": 1
+    "application": 1
 }' | jq -M .
 
-curl -X POST ${host}/repositories/1/identities -d \
+curl -X POST ${host}/application-inventory/application/1/identities -d \
 '{
     "createUser": "tackle",
     "kind": "mvn",

--- a/hack/add/proxy.sh
+++ b/hack/add/proxy.sh
@@ -7,9 +7,7 @@ curl -X POST ${host}/proxies -d \
     "createUser": "tackle",
     "kind": "http",
     "host":"myhost",
-    "port": 80,
-    "user": "userA",
-    "password": "passwordA"
+    "port": 80
 }' | jq -M .
 
 curl -X POST ${host}/proxies -d \
@@ -17,7 +15,5 @@ curl -X POST ${host}/proxies -d \
     "createUser": "tackle",
     "kind": "https",
     "host":"myhost",
-    "port": 443,
-    "user": "userB",
-    "password": "passwordB"
+    "port": 443
 }' | jq -M .

--- a/model/application.go
+++ b/model/application.go
@@ -9,6 +9,7 @@ type Application struct {
 	Review            *Review          `json:"review"`
 	Comments          string           `json:"comments"`
 	Tags              []Tag            `json:"tags" gorm:"many2many:applicationTags"`
+	Identities        []Identity       `json:"identities" gorm:"many2many:appIdentity"`
 	BusinessServiceID uint             `json:"-" gorm:"index"`
 	BusinessService   *BusinessService `json:"businessService"`
 }
@@ -24,12 +25,11 @@ type Dependency struct {
 type Repository struct {
 	Model
 	Kind          string `json:"kind"`
-	Binary        bool   `json:"binary" gorm:"uniqueIndex:Repository_A"`
 	URL           string `json:"url"`
 	Branch        string `json:"branch"`
 	Tag           string `json:"tag"`
 	Path          string `json:"path" gorm:"default:/"`
-	ApplicationID uint   `json:"application" gorm:"index;uniqueIndex:Repository_A"`
+	ApplicationID uint   `json:"application" gorm:"index;unique"`
 }
 
 type Review struct {

--- a/model/identity.go
+++ b/model/identity.go
@@ -8,6 +8,7 @@ import (
 
 //
 // Identity represents and identity with a set of credentials.
+// Kinds = (git|svn|mvn|proxy)
 type Identity struct {
 	Model
 	Kind          string `json:"kind" gorm:"not null"`

--- a/model/identity.go
+++ b/model/identity.go
@@ -6,17 +6,19 @@ import (
 	"gorm.io/gorm"
 )
 
+//
+// Identity represents and identity with a set of credentials.
 type Identity struct {
 	Model
-	Kind         string `json:"kind" gorm:"not null;uniqueIndex:Identity_A"`
-	Name         string `json:"name" gorm:"not null"`
-	Description  string `json:"description"`
-	User         string `json:"user"`
-	Password     string `json:"password"`
-	Key          string `json:"key"`
-	Settings     string `json:"settings"`
-	Encrypted    string `json:"encrypted"`
-	RepositoryID uint   `json:"repository" gorm:"index;uniqueIndex:Identity_A"`
+	Kind          string `json:"kind" gorm:"not null"`
+	Name          string `json:"name" gorm:"not null"`
+	Description   string `json:"description"`
+	User          string `json:"user"`
+	Password      string `json:"password"`
+	Key           string `json:"key"`
+	Settings      string `json:"settings"`
+	Encrypted     string `json:"encrypted"`
+	ApplicationID uint   `json:"application" gorm:"many2many:appIdentity"`
 }
 
 //
@@ -73,7 +75,7 @@ func (r *Identity) BeforeSave(tx *gorm.DB) (err error) {
 }
 
 //
-// encrypted returns the encrypted identity.
+// encrypted returns the encrypted credentials.
 func (r *Identity) encrypted(passphrase string) (encrypted *Identity, err error) {
 	aes := encryption.New(passphrase)
 	encrypted = &Identity{}

--- a/model/proxy.go
+++ b/model/proxy.go
@@ -1,11 +1,5 @@
 package model
 
-import (
-	"encoding/json"
-	"github.com/konveyor/tackle-hub/encryption"
-	"gorm.io/gorm"
-)
-
 //
 // Proxy configuration.
 // kind = (http|https)
@@ -14,71 +8,5 @@ type Proxy struct {
 	Kind       string `json:"kind" gorm:"uniqueIndex"`
 	Host       string `json:"host" gorm:"not null"`
 	Port       int    `json:"port"`
-	User       string `json:"user"`
-	Password   string `json:"password"`
-	IdentityID uint   `json:"identity"`
-	Encrypted  string `json:"encrypted"`
-}
-
-//
-// Encrypt sensitive fields.
-func (r *Proxy) Encrypt(passphrase string) (err error) {
-	aes := encryption.New(passphrase)
-	encrypted, err := r.encrypted(passphrase)
-	if err != nil {
-		return
-	}
-	if r.User != "" {
-		encrypted.User = r.User
-		r.User = ""
-	}
-	if r.Password != "" {
-		encrypted.Password = r.Password
-		r.Password = ""
-	}
-	b, err := json.Marshal(encrypted)
-	if err != nil {
-		return
-	}
-	r.Encrypted, err = aes.Encrypt(string(b))
-	return
-}
-
-//
-// Decrypt sensitive fields.
-func (r *Proxy) Decrypt(passphrase string) (err error) {
-	encrypted, err := r.encrypted(passphrase)
-	if err != nil {
-		return
-	}
-	r.User = encrypted.User
-	r.Password = encrypted.Password
-
-	return
-}
-
-//
-// BeforeSave ensure encrypted.
-func (r *Proxy) BeforeSave(tx *gorm.DB) (err error) {
-	err = r.Encrypt(Settings.Encryption.Passphrase)
-	return
-}
-
-//
-// encrypted returns the encrypted identity.
-func (r *Proxy) encrypted(passphrase string) (encrypted *Identity, err error) {
-	aes := encryption.New(passphrase)
-	encrypted = &Identity{}
-	if r.Encrypted != "" {
-		var dj string
-		dj, err = aes.Decrypt(r.Encrypted)
-		if err != nil {
-			return
-		}
-		err = json.Unmarshal([]byte(dj), encrypted)
-		if err != nil {
-			return
-		}
-	}
-	return
+	IdentityID uint   `json:"identity" gorm:"index"`
 }


### PR DESCRIPTION
Identity needs to be associated (many2many) with Applications instead of Repositories.
Proxy credentials should be stored as `Identity`.